### PR TITLE
refactor(Driver): 简化 Redis 限流器实现逻辑

### DIFF
--- a/src/Driver/Redis.php
+++ b/src/Driver/Redis.php
@@ -23,59 +23,22 @@ class Redis implements DriverInterface
      */
     public function increase(string $key, int $ttl = 24 * 60 * 60, $step = 1): int
     {
-        static $hashKeyExpireAtMap = [];
-        $connection = RedisClient::connection($this->connection);
-        
-        // 计算当前请求所属 TTL 窗口的过期时间点（固定窗口）
-        $expireTime = $this->getExpireTime($ttl);
-        
-        // 以天为最小分段：TTL 向上取整到天，得到分段长度（单位：秒）
-        $segmentDays = (int)ceil($ttl / (24 * 60 * 60));
-        if ($segmentDays < 1) {
-            $segmentDays = 1;
-        }
-        $segmentSeconds = $segmentDays * 24 * 60 * 60;
-        
-        // 找到窗口过期时间所在“天”的起始时刻（本地时间），并据此锚定到 N 天段的起始时刻
-        $expireDayStart = strtotime(date('Y-m-d', $expireTime));
-        $segmentStart = (int) (floor($expireDayStart / $segmentSeconds) * $segmentSeconds);
-        $segmentEnd = $segmentStart + $segmentSeconds;
-        
-        // 使用分段起始日作为 hashKey 的日期部分
-        $hashKey = 'rate-limiter-' . date('Y-m-d', $segmentStart);
-        
-        // field 按窗口过期时间与 TTL 唯一标识该 TTL 窗口
-        $field = $key . '-' . $expireTime . '-' . $ttl;
+      $redis = RedisClient::connection($this->connection);
+      $now = time();
+      $windowStart = $now - ($now % $ttl);
+      $windowEnd = $windowStart + $ttl;
+      $hashKey = "rate_limit:{$key}:{$windowStart}";
 
-        $count = $connection->hIncrBy($hashKey, $field, $step) ?: 0;
+      try {
+        $count = $redis->hIncrBy($hashKey, 'counter', (int)$step);
 
-        // 设置当前 hashKey 的过期时间为分段结束时刻，仅延长不过期
-        $expireAt = $segmentEnd;
-        $currentRecordedExpireAt = $hashKeyExpireAtMap[$hashKey] ?? null;
-        if ($currentRecordedExpireAt === null || $expireAt > $currentRecordedExpireAt) {
-            // 仅在需要更新 Redis 过期时间时才清理内存 map，避免频繁遍历
-            if (!empty($hashKeyExpireAtMap)) {
-                $now = time();
-                foreach ($hashKeyExpireAtMap as $k => $expAt) {
-                    if ($expAt <= $now) {
-                        unset($hashKeyExpireAtMap[$k]);
-                    }
-                }
-            }
-
-            $connection->expireAt($hashKey, $expireAt);
-            $hashKeyExpireAtMap[$hashKey] = $expireAt;
+        if ($count == $step) {
+          $redis->expireAt($hashKey, $windowEnd);
         }
 
         return $count;
-    }
-
-    /**
-     * @param $ttl
-     * @return int
-     */
-    protected function getExpireTime($ttl): int
-    {
-        return ceil(time() / $ttl) * $ttl;
+      } catch (RedisException $e) {
+        return 0;
+      }
     }
 }


### PR DESCRIPTION
- 移除复杂的哈希键过期时间映射机制
- 使用简单的时间窗口算法替代分段计算逻辑
- 直接使用当前时间计算窗口开始和结束时间
- 简化哈希键结构，移除冗余字段
- 添加异常处理机制确保操作安全性
- 移除过期的 getExpireTime 方法和相关复杂计算

原来的逻辑使用静态变量做状态管理会在项目重启初期出现限流失效混乱情况：（下图为设置限流1/5s）
<img width="344" height="503" alt="屏幕截图_20260214_210108" src="https://github.com/user-attachments/assets/6e2d5236-89b9-4fc0-a821-fcc4f14f06bd" />

优化后：
<img width="386" height="344" alt="屏幕截图_20260214_204022" src="https://github.com/user-attachments/assets/731ad253-5036-4e7c-8e34-ea723c93f76e" />
